### PR TITLE
Quiz preview ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/node": "^16.18.70",
         "@types/react": "^18.2.47",
         "@types/react-dom": "^18.2.18",
+        "axios": "^1.6.8",
         "bootstrap": "^5.3.2",
         "date-fns": "^3.6.0",
         "dompurify": "^3.1.0",
@@ -5244,6 +5245,29 @@
         "node": ">=4"
       }
     },
+    "node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
@@ -6984,14 +7008,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/dotenv-expand": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
@@ -8290,9 +8306,9 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -14600,6 +14616,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -15035,6 +15056,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/node": "^16.18.70",
     "@types/react": "^18.2.47",
     "@types/react-dom": "^18.2.18",
+    "axios": "^1.6.8",
     "bootstrap": "^5.3.2",
     "date-fns": "^3.6.0",
     "dompurify": "^3.1.0",

--- a/src/Kanbas/Courses/Quizzes/Preview/Answers.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/Answers.tsx
@@ -1,44 +1,64 @@
-import { Answer, QuestionType } from '.';
+import { QuestionType } from '.';
+import useQuizPreview from '../hooks/useQuizPreview';
 
 export interface AnswersProps {
-  answers: Answer[];
+  options: string[];
+  questionIndex: number;
   variant?: QuestionType;
+  handleAnswerSelect: (answer: string, answerIndex: number) => void;
 }
 export default function Answers({
-  answers,
+  options,
+  questionIndex,
   variant = QuestionType.MULTIPLE_CHOICE,
+  handleAnswerSelect,
 }: AnswersProps) {
+  const { answers } = useQuizPreview();
+
   switch (variant) {
     case QuestionType.MULTIPLE_CHOICE:
     case QuestionType.TRUE_FALSE:
       return (
         <div>
-          {answers.map((answer, index) => (
-            <div className='question-multiple-choice-answer-input' key={index}>
-              <input
-                className='focus-ring'
-                id={answer.answer}
-                type='radio'
-                name='answer'
-                value={answer.answer}
-              />
-              <label className='w-100' htmlFor={answer.answer}>
-                {answer.answer}
-              </label>
-            </div>
-          ))}
+          {options.map((option, index) => {
+            return (
+              <div
+                className='question-multiple-choice-answer-input'
+                key={index}
+              >
+                <input
+                  className='focus-ring'
+                  id={option}
+                  type='radio'
+                  name={`question-${questionIndex}`}
+                  checked={option === answers[questionIndex][0]}
+                  value={option}
+                  onChange={() => handleAnswerSelect(option, 0)}
+                />
+                <label className='w-100' htmlFor={option}>
+                  {option}
+                </label>
+              </div>
+            );
+          })}
         </div>
       );
     case QuestionType.FILL_IN_THE_BLANK:
       return (
         <div className='d-flex flex-column gap-2'>
-          {answers.map((answer, index) => (
+          {options.map((option, index) => (
             <div
               className='question-fill-in-the-blank-answer-input'
               key={index}
             >
-              <label htmlFor={answer.answer}>{index + 1}.</label>
-              <input className='p-2' id={answer.answer} type='text' />
+              <label htmlFor={option}>{index + 1}.</label>
+              <input
+                className='p-2'
+                id={option}
+                value={answers[questionIndex][index]}
+                type='text'
+                onChange={(e) => handleAnswerSelect(e.target.value, index)}
+              />
             </div>
           ))}
         </div>

--- a/src/Kanbas/Courses/Quizzes/Preview/Answers.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/Answers.tsx
@@ -1,5 +1,5 @@
-import { QuestionType } from '.';
 import useQuizPreview from '../hooks/useQuizPreview';
+import { QuestionType } from './constants';
 
 export interface AnswersProps {
   options: string[];
@@ -7,6 +7,7 @@ export interface AnswersProps {
   variant?: QuestionType;
   handleAnswerSelect: (answer: string, answerIndex: number) => void;
 }
+
 export default function Answers({
   options,
   questionIndex,

--- a/src/Kanbas/Courses/Quizzes/Preview/QuestionBox.css
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuestionBox.css
@@ -3,19 +3,19 @@
   flex-direction: column;
   align-items: end;
   gap: 2.5rem;
-  max-width: 600px;
+  max-width: 650px;
+}
+
+.question-box-grid {
+  display: grid;
+  grid-template-columns: 50px minmax(auto, 600px) 50px;
+  width: 100%;
 }
 
 .question-box {
   border: 1px solid rgb(206, 206, 206);
-}
-
-.next-question-btn {
-  width: fit-content;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: 0.25rem;
+  max-width: 600px;
+  width: 100%;
 }
 
 .question-box-header {
@@ -47,4 +47,13 @@
 
 .question-fill-in-the-blank-answer-input input {
   width: 150px;
+}
+
+.question-box-tag {
+  margin-top: 12px;
+  font-size: 24px;
+}
+
+.question-box-tag:hover {
+  cursor: pointer;
 }

--- a/src/Kanbas/Courses/Quizzes/Preview/QuestionBox.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuestionBox.tsx
@@ -1,15 +1,3 @@
-/**
- * the question box with all the question details and stuff
- * <BiSolidTag />
- * <BiTag />
- * 
- * 
- * use these ones:
-<PiTagSimple />
-<PiTagSimpleFill />
-
-
- */
 import { PiTagSimple, PiTagSimpleFill } from 'react-icons/pi';
 import { Question } from '.';
 import * as DOMPurify from 'dompurify';
@@ -24,9 +12,6 @@ export interface QuestionBoxProps {
   handleAnswerSelect: (answer: string, answerIndex: number) => void;
 }
 
-const testDesc =
-  '<p>This is a test <strong>question</strong> <s><u>description</u></s> with different types of editor styling.<em> This is Italics </em><strong><em>woah....</em></strong> back to normal!</p><p><br></p><p>Line break goes crazy!</p>';
-
 export default function QuestionBox({
   question,
   questionIndex,
@@ -34,7 +19,6 @@ export default function QuestionBox({
 }: QuestionBoxProps) {
   const { taggedQuestions, updateTaggedQuestion } = useQuizPreview();
   const descriptionSanitized = DOMPurify.sanitize(question.description);
-  // const descriptionSanitized = DOMPurify.sanitize(testDesc);
 
   const handleTagClick = () => updateTaggedQuestion(questionIndex);
 
@@ -61,7 +45,7 @@ export default function QuestionBox({
           </div>
         </div>
         <div className='d-flex flex-column mt-1 pt-4 pb-3 px-3'>
-          {parse(descriptionSanitized)}
+          <p>{parse(descriptionSanitized)}</p>
           <Answers
             options={question.options}
             variant={question.type}

--- a/src/Kanbas/Courses/Quizzes/Preview/QuestionBox.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuestionBox.tsx
@@ -32,7 +32,7 @@ export default function QuestionBox({
   questionIndex,
   handleAnswerSelect,
 }: QuestionBoxProps) {
-  const { taggedQuestionIndex, updateTaggedQuestion } = useQuizPreview();
+  const { taggedQuestions, updateTaggedQuestion } = useQuizPreview();
   const descriptionSanitized = DOMPurify.sanitize(question.description);
   // const descriptionSanitized = DOMPurify.sanitize(testDesc);
 
@@ -41,7 +41,7 @@ export default function QuestionBox({
   return (
     <div className='question-box-grid'>
       <div className='d-flex justify-content-center'>
-        {taggedQuestionIndex === questionIndex ? (
+        {taggedQuestions.includes(questionIndex) ? (
           <PiTagSimpleFill
             className='question-box-tag'
             style={{ color: '#EBBC4E' }}

--- a/src/Kanbas/Courses/Quizzes/Preview/QuestionBox.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuestionBox.tsx
@@ -12,48 +12,66 @@
  */
 import { PiTagSimple, PiTagSimpleFill } from 'react-icons/pi';
 import { Question } from '.';
-import { useState } from 'react';
 import * as DOMPurify from 'dompurify';
 import parse from 'html-react-parser';
 import './QuestionBox.css';
 import Answers from './Answers';
+import useQuizPreview from '../hooks/useQuizPreview';
 
 export interface QuestionBoxProps {
   question: Question;
+  questionIndex: number;
+  handleAnswerSelect: (answer: string, answerIndex: number) => void;
 }
-
-const tagStyle = {
-  position: 'relative',
-  top: 0,
-  right: 0,
-  transform: 'translateX(-10px)',
-  fontSize: '1.5rem',
-  color: 'black',
-} as React.CSSProperties;
 
 const testDesc =
   '<p>This is a test <strong>question</strong> <s><u>description</u></s> with different types of editor styling.<em> This is Italics </em><strong><em>woah....</em></strong> back to normal!</p><p><br></p><p>Line break goes crazy!</p>';
 
-export default function QuestionBox({ question }: QuestionBoxProps) {
-  const descriptionSanitized = DOMPurify.sanitize(testDesc);
+export default function QuestionBox({
+  question,
+  questionIndex,
+  handleAnswerSelect,
+}: QuestionBoxProps) {
+  const { taggedQuestionIndex, updateTaggedQuestion } = useQuizPreview();
+  const descriptionSanitized = DOMPurify.sanitize(question.description);
+  // const descriptionSanitized = DOMPurify.sanitize(testDesc);
+
+  const handleTagClick = () => updateTaggedQuestion(questionIndex);
+
   return (
-    <div className='d-flex flex-column question-box'>
-      <div className='d-flex flex-row question-box-header'>
-        {/* {tagged ? (
-          <PiTagSimpleFill style={tagStyle} />
+    <div className='question-box-grid'>
+      <div className='d-flex justify-content-center'>
+        {taggedQuestionIndex === questionIndex ? (
+          <PiTagSimpleFill
+            className='question-box-tag'
+            style={{ color: '#EBBC4E' }}
+            onClick={handleTagClick}
+          />
         ) : (
-          <PiTagSimple style={tagStyle} />
-        )} */}
-        <div className='d-flex flex-row w-100 py-2 px-4 justify-content-between align-items-center'>
-          <p className='m-0 pt-1'>{question.title}</p>
-          <p className='m-0 pt-1' style={{ color: '#6E7173' }}>
-            {question.points} pts
-          </p>
+          <PiTagSimple className='question-box-tag' onClick={handleTagClick} />
+        )}
+      </div>
+      <div className='d-flex flex-column question-box'>
+        <div className='d-flex flex-row question-box-header'>
+          <div className='d-flex flex-row w-100 py-2 px-4 justify-content-between align-items-center'>
+            <p className='m-0 pt-1'>{question.title}</p>
+            <p className='m-0 pt-1' style={{ color: '#6E7173' }}>
+              {question.points} pts
+            </p>
+          </div>
+        </div>
+        <div className='d-flex flex-column mt-1 pt-4 pb-3 px-3'>
+          {parse(descriptionSanitized)}
+          <Answers
+            options={question.options}
+            variant={question.type}
+            questionIndex={questionIndex}
+            handleAnswerSelect={handleAnswerSelect}
+          />
         </div>
       </div>
-      <div className='d-flex flex-column mt-1 pt-4 pb-3 px-3'>
-        {parse(descriptionSanitized)}
-        <Answers answers={question.answers} variant={question.type} />
+      <div>
+        {/* Intentionally left empty so that the grid template works out */}
       </div>
     </div>
   );

--- a/src/Kanbas/Courses/Quizzes/Preview/QuestionList.css
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuestionList.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.1rem;
-  margin-left: 2rem;
+  margin-left: 1.5rem;
   padding: 0;
 }
 
@@ -10,13 +10,31 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.5rem;
   list-style-type: none;
+  margin: 0;
+  padding: 0;
+}
+
+.question-list-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.25rem;
   margin: 0;
   padding: 0;
   color: red;
 }
 
 .question-list-container li:hover {
+  cursor: pointer;
+}
+
+.question-list-tag {
+  font-size: 16px;
+  font-weight: normal;
+}
+
+.question-list-tag:hover {
   cursor: pointer;
 }

--- a/src/Kanbas/Courses/Quizzes/Preview/QuestionList.css
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuestionList.css
@@ -26,15 +26,12 @@
   color: red;
 }
 
-.question-list-container li:hover {
+.question-list-item:hover {
   cursor: pointer;
 }
 
 .question-list-tag {
   font-size: 16px;
   font-weight: normal;
-}
-
-.question-list-tag:hover {
-  cursor: pointer;
+  color: #ebbc4e;
 }

--- a/src/Kanbas/Courses/Quizzes/Preview/QuestionList.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuestionList.tsx
@@ -15,7 +15,7 @@ export default function QuestionList({
   currentQuestionIndex,
   handleChangeQuestion,
 }: QuestionListProps) {
-  const { taggedQuestionIndex, updateTaggedQuestion } = useQuizPreview();
+  const { taggedQuestions } = useQuizPreview();
 
   return (
     <div
@@ -32,18 +32,11 @@ export default function QuestionList({
             key={index}
             className={index === currentQuestionIndex ? 'fw-bold' : ''}
           >
-            {taggedQuestionIndex === index ? (
-              <PiTagSimpleFill
-                className='question-list-tag'
-                style={{ color: '#EBBC4E' }}
-                onClick={() => updateTaggedQuestion(index)}
-              />
-            ) : (
-              <PiTagSimple
-                className='question-list-tag'
-                onClick={() => updateTaggedQuestion(index)}
-              />
-            )}
+            <div style={{ width: '20px' }}>
+              {taggedQuestions.includes(index) && (
+                <PiTagSimpleFill className='question-list-tag' />
+              )}
+            </div>
             <div
               className='question-list-item'
               onClick={() => handleChangeQuestion(index)}

--- a/src/Kanbas/Courses/Quizzes/Preview/QuestionList.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuestionList.tsx
@@ -1,6 +1,8 @@
 import { Question } from '.';
 import { AiOutlineQuestionCircle } from 'react-icons/ai';
+import { PiTagSimple, PiTagSimpleFill } from 'react-icons/pi';
 import './QuestionList.css';
+import useQuizPreview from '../hooks/useQuizPreview';
 
 export interface QuestionListProps {
   questions: Question[];
@@ -13,22 +15,46 @@ export default function QuestionList({
   currentQuestionIndex,
   handleChangeQuestion,
 }: QuestionListProps) {
+  const { taggedQuestionIndex, updateTaggedQuestion } = useQuizPreview();
+
   return (
-    <div className='d-flex flex-column my-5'>
+    <div
+      className='d-flex flex-column my-5'
+      style={{
+        minWidth: '250px',
+        width: '250px',
+      }}
+    >
       <h3>Questions</h3>
       <ul className='question-list-container'>
         {questions.map((question, index) => (
           <li
             key={index}
             className={index === currentQuestionIndex ? 'fw-bold' : ''}
-            onClick={() => handleChangeQuestion(index)}
           >
-            <AiOutlineQuestionCircle
-              style={{
-                color: 'rgb(110, 113, 115)',
-              }}
-            />
-            {question.title}
+            {taggedQuestionIndex === index ? (
+              <PiTagSimpleFill
+                className='question-list-tag'
+                style={{ color: '#EBBC4E' }}
+                onClick={() => updateTaggedQuestion(index)}
+              />
+            ) : (
+              <PiTagSimple
+                className='question-list-tag'
+                onClick={() => updateTaggedQuestion(index)}
+              />
+            )}
+            <div
+              className='question-list-item'
+              onClick={() => handleChangeQuestion(index)}
+            >
+              <AiOutlineQuestionCircle
+                style={{
+                  color: 'rgb(110, 113, 115)',
+                }}
+              />
+              {question.title}
+            </div>
           </li>
         ))}
       </ul>

--- a/src/Kanbas/Courses/Quizzes/Preview/QuestionList.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuestionList.tsx
@@ -1,6 +1,6 @@
 import { Question } from '.';
 import { AiOutlineQuestionCircle } from 'react-icons/ai';
-import { PiTagSimple, PiTagSimpleFill } from 'react-icons/pi';
+import { PiTagSimpleFill } from 'react-icons/pi';
 import './QuestionList.css';
 import useQuizPreview from '../hooks/useQuizPreview';
 

--- a/src/Kanbas/Courses/Quizzes/Preview/QuizContent.css
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuizContent.css
@@ -1,3 +1,20 @@
 .submit-btn-container {
   margin: 2.5rem 1.5rem 3rem 1.5rem !important;
 }
+
+.next-question-btn,
+.prev-question-btn {
+  width: fit-content;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.1rem;
+}
+
+.quiz-content-container {
+  max-width: 800px;
+}
+
+.question-list-sidebar {
+  max-width: 400px;
+}

--- a/src/Kanbas/Courses/Quizzes/Preview/QuizContent.css
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuizContent.css
@@ -11,6 +11,17 @@
   gap: 0.1rem;
 }
 
+.disabled-btn {
+  cursor: not-allowed !important;
+}
+
+.submit-btn:disabled,
+.submit-btn[disabled] {
+  background-color: rgb(239, 239, 239);
+  color: rgb(41, 41, 41);
+  border-color: rgb(187, 187, 187);
+}
+
 .quiz-content-container {
   max-width: 800px;
 }

--- a/src/Kanbas/Courses/Quizzes/Preview/QuizContent.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuizContent.tsx
@@ -5,6 +5,7 @@ import { MdArrowRight, MdArrowLeft, MdOutlineEdit } from 'react-icons/md';
 import './QuizContent.css';
 import { useState } from 'react';
 import useQuizPreview from '../hooks/useQuizPreview';
+import { Link, useParams } from 'react-router-dom';
 
 /**
  * from quiz instructions to keep editing this quiz button
@@ -15,7 +16,6 @@ export interface QuizContentProps {
   currentQuestionIndex: number;
   questions: Question[];
   handleChangeQuestion: React.Dispatch<React.SetStateAction<number>>;
-  handleEdit: () => void;
   handleSubmit: () => void;
   handleSaveAnswer: (
     answer: string,
@@ -31,10 +31,10 @@ export default function QuizContent({
   currentQuestionIndex,
   questions,
   handleChangeQuestion,
-  handleEdit,
   handleSubmit,
   handleSaveAnswer,
 }: QuizContentProps) {
+  const { courseId, quizId } = useParams();
   const { answers } = useQuizPreview();
   const [formattedSavedAt, setFormattedSavedAt] = useState(
     format(new Date(), UPDATED_AT_DATE_FORMAT)
@@ -116,28 +116,32 @@ export default function QuizContent({
         <p className='m-0 p-0' style={{ color: '#6E7173' }}>
           Quiz saved at {formattedSavedAt}
         </p>
-        <button
-          className={`btn ${
-            answers.every((answer) => answer.every((ans) => ans !== ''))
-              ? 'btn-danger'
-              : 'wd-modules-btn'
-          }`}
-          onClick={handleSubmit}
-        >
-          Submit Quiz
-        </button>
+        <div className='disabled-btn'>
+          <button
+            className={`btn ${
+              answers.every((answer) => answer.every((ans) => ans !== ''))
+                ? 'btn-danger'
+                : 'submit-btn'
+            }`}
+            disabled
+          >
+            Submit Quiz
+          </button>
+        </div>
       </div>
-      <button
-        className='btn wd-modules-btn d-flex justify-content-start gap-1 mt-4'
-        onClick={handleEdit}
+      <Link
+        to={`/Kanbas/Courses/${courseId}/Quizzes/${quizId}`}
+        className='w-100 mt-4 text-decoration-none'
       >
-        <MdOutlineEdit
-          style={{
-            transform: 'rotateY(180deg)',
-          }}
-        />
-        Keep Editing This Quiz
-      </button>
+        <button className='btn wd-modules-btn d-flex justify-content-start gap-1 w-100'>
+          <MdOutlineEdit
+            style={{
+              transform: 'rotateY(180deg)',
+            }}
+          />
+          Keep Editing This Quiz
+        </button>
+      </Link>
     </div>
   );
 }

--- a/src/Kanbas/Courses/Quizzes/Preview/QuizContent.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuizContent.tsx
@@ -4,6 +4,7 @@ import QuestionBox from './QuestionBox';
 import { MdArrowRight, MdArrowLeft, MdOutlineEdit } from 'react-icons/md';
 import './QuizContent.css';
 import { useState } from 'react';
+import useQuizPreview from '../hooks/useQuizPreview';
 
 /**
  * from quiz instructions to keep editing this quiz button
@@ -34,6 +35,7 @@ export default function QuizContent({
   handleSubmit,
   handleSaveAnswer,
 }: QuizContentProps) {
+  const { answers } = useQuizPreview();
   const [formattedSavedAt, setFormattedSavedAt] = useState(
     format(new Date(), UPDATED_AT_DATE_FORMAT)
   );
@@ -67,6 +69,9 @@ export default function QuizContent({
                   ? 'justify-content-end'
                   : 'justify-content-between'
               }`}
+              style={{
+                padding: '0 50px',
+              }}
             >
               {currentQuestionIndex > 0 && (
                 <button
@@ -111,7 +116,14 @@ export default function QuizContent({
         <p className='m-0 p-0' style={{ color: '#6E7173' }}>
           Quiz saved at {formattedSavedAt}
         </p>
-        <button className='btn wd-modules-btn' onClick={handleSubmit}>
+        <button
+          className={`btn ${
+            answers.every((answer) => answer.every((ans) => ans !== ''))
+              ? 'btn-danger'
+              : 'wd-modules-btn'
+          }`}
+          onClick={handleSubmit}
+        >
           Submit Quiz
         </button>
       </div>

--- a/src/Kanbas/Courses/Quizzes/Preview/QuizContent.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuizContent.tsx
@@ -6,10 +6,7 @@ import './QuizContent.css';
 import { useState } from 'react';
 import useQuizPreview from '../hooks/useQuizPreview';
 import { Link, useParams } from 'react-router-dom';
-
-/**
- * from quiz instructions to keep editing this quiz button
- */
+import { UPDATED_AT_DATE_FORMAT } from './constants';
 
 export interface QuizContentProps {
   oneQuestionAtATime: boolean;
@@ -23,8 +20,6 @@ export interface QuizContentProps {
     questionIndex: number
   ) => void;
 }
-
-export const UPDATED_AT_DATE_FORMAT = 'h:mmaaa';
 
 export default function QuizContent({
   oneQuestionAtATime,

--- a/src/Kanbas/Courses/Quizzes/Preview/QuizContent.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/QuizContent.tsx
@@ -1,9 +1,9 @@
 import { format } from 'date-fns';
 import { Question } from '.';
-import { quizzes } from '../../../Database';
 import QuestionBox from './QuestionBox';
-import { MdArrowRight, MdOutlineEdit } from 'react-icons/md';
+import { MdArrowRight, MdArrowLeft, MdOutlineEdit } from 'react-icons/md';
 import './QuizContent.css';
+import { useState } from 'react';
 
 /**
  * from quiz instructions to keep editing this quiz button
@@ -16,6 +16,11 @@ export interface QuizContentProps {
   handleChangeQuestion: React.Dispatch<React.SetStateAction<number>>;
   handleEdit: () => void;
   handleSubmit: () => void;
+  handleSaveAnswer: (
+    answer: string,
+    answerIndex: number,
+    questionIndex: number
+  ) => void;
 }
 
 export const UPDATED_AT_DATE_FORMAT = 'h:mmaaa';
@@ -27,9 +32,21 @@ export default function QuizContent({
   handleChangeQuestion,
   handleEdit,
   handleSubmit,
+  handleSaveAnswer,
 }: QuizContentProps) {
-  // TODO: update this to pull the updated at date from BE
-  const formattedUpdatedAt = format(new Date(), UPDATED_AT_DATE_FORMAT);
+  const [formattedSavedAt, setFormattedSavedAt] = useState(
+    format(new Date(), UPDATED_AT_DATE_FORMAT)
+  );
+
+  const handleAnswerSelect = (
+    answer: string,
+    answerIndex: number,
+    questionIndex: number
+  ) => {
+    handleSaveAnswer(answer, answerIndex, questionIndex);
+    setFormattedSavedAt(format(new Date(), UPDATED_AT_DATE_FORMAT));
+  };
+
   return (
     <div className='d-flex flex-column gap-1'>
       <h3 className='m-0 p-0 fw-bold'>Quiz Instructions</h3>
@@ -38,22 +55,49 @@ export default function QuizContent({
         {oneQuestionAtATime && (
           <>
             <QuestionBox
-              question={quizzes[0].questions[currentQuestionIndex] as Question}
+              question={questions[currentQuestionIndex]}
+              questionIndex={currentQuestionIndex}
+              handleAnswerSelect={(answer: string, answerIndex: number) =>
+                handleAnswerSelect(answer, answerIndex, currentQuestionIndex)
+              }
             />
-            {currentQuestionIndex < questions.length - 1 && (
-              <button
-                className='btn wd-modules-btn next-question-btn'
-                onClick={() => handleChangeQuestion((index) => index + 1)}
-              >
-                Next <MdArrowRight style={{ fontSize: '20px' }} />
-              </button>
-            )}
+            <div
+              className={`d-flex flex-row w-100 ${
+                currentQuestionIndex === 0
+                  ? 'justify-content-end'
+                  : 'justify-content-between'
+              }`}
+            >
+              {currentQuestionIndex > 0 && (
+                <button
+                  className='btn wd-modules-btn prev-question-btn'
+                  onClick={() => handleChangeQuestion((index) => index - 1)}
+                >
+                  <MdArrowLeft style={{ fontSize: '20px' }} /> Previous
+                </button>
+              )}
+              {currentQuestionIndex < questions.length - 1 && (
+                <button
+                  className='btn btn-danger next-question-btn'
+                  onClick={() => handleChangeQuestion((index) => index + 1)}
+                >
+                  Next <MdArrowRight style={{ fontSize: '20px' }} />
+                </button>
+              )}
+            </div>
           </>
         )}
         {!oneQuestionAtATime && (
           <>
             {questions.map((question, index) => (
-              <QuestionBox key={index} question={question} />
+              <QuestionBox
+                key={index}
+                question={question}
+                questionIndex={index}
+                handleAnswerSelect={(answer: string, answerIndex: number) =>
+                  handleAnswerSelect(answer, answerIndex, index)
+                }
+              />
             ))}
           </>
         )}
@@ -65,7 +109,7 @@ export default function QuizContent({
         }}
       >
         <p className='m-0 p-0' style={{ color: '#6E7173' }}>
-          Quiz saved at {formattedUpdatedAt}
+          Quiz saved at {formattedSavedAt}
         </p>
         <button className='btn wd-modules-btn' onClick={handleSubmit}>
           Submit Quiz

--- a/src/Kanbas/Courses/Quizzes/Preview/client.ts
+++ b/src/Kanbas/Courses/Quizzes/Preview/client.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+import { Quiz } from '.';
+export const BASE_API = process.env.REACT_APP_BASE_API_URL;
+export const QUIZZES_API = `${BASE_API}/api/quizzes`;
+export const findQuizById = async (quizId: string): Promise<Quiz> => {
+  const response = await axios.get(`${QUIZZES_API}/${quizId}`);
+  console.log('axios response', response);
+  return response.data;
+};

--- a/src/Kanbas/Courses/Quizzes/Preview/client.ts
+++ b/src/Kanbas/Courses/Quizzes/Preview/client.ts
@@ -4,6 +4,5 @@ export const BASE_API = process.env.REACT_APP_BASE_API_URL;
 export const QUIZZES_API = `${BASE_API}/api/quizzes`;
 export const findQuizById = async (quizId: string): Promise<Quiz> => {
   const response = await axios.get(`${QUIZZES_API}/${quizId}`);
-  console.log('axios response', response);
   return response.data;
 };

--- a/src/Kanbas/Courses/Quizzes/Preview/constants.ts
+++ b/src/Kanbas/Courses/Quizzes/Preview/constants.ts
@@ -1,0 +1,21 @@
+export const UPDATED_AT_DATE_FORMAT = 'h:mmaaa';
+
+export enum QuestionType {
+  MULTIPLE_CHOICE = 'Multiple Choice',
+  TRUE_FALSE = 'True/False',
+  FILL_IN_THE_BLANK = 'Fill in the Blank',
+}
+
+export enum QuizType {
+  GRADED_QUIZ = 'Graded Quiz',
+  PRACTICE_QUIZ = 'Practice Quiz',
+  GRADED_SURVEY = 'Graded Survey',
+  UNGRADED_SURVEY = 'Ungraded Survey',
+}
+
+export enum AssignmentGroup {
+  QUIZZES = 'Quizzes',
+  ASSIGNMENTS = 'Assignments',
+  EXAMS = 'Exams',
+  PROJECTS = 'Projects',
+}

--- a/src/Kanbas/Courses/Quizzes/Preview/index.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/index.tsx
@@ -61,6 +61,8 @@ const QuizPreview = () => {
         const res = await client.findQuizById(quizId);
         console.log('res', res);
         setQuiz(res);
+
+        // initialize answers array to have an empty string string for each question/fill in the blank
         setAnswers(
           res.questions.map((question) =>
             question.type === QuestionType.FILL_IN_THE_BLANK

--- a/src/Kanbas/Courses/Quizzes/Preview/index.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/index.tsx
@@ -81,9 +81,7 @@ const QuizPreview = () => {
   const [quiz, setQuiz] = useState<Quiz | null>(null);
   // TODO: the datatype of this array might need to change
   const [answers, setAnswers] = useState<string[][]>([]);
-  const [taggedQuestionIndex, setTaggedQuestionIndex] = useState<number | null>(
-    null
-  );
+  const [taggedQuestions, setTaggedQuestions] = useState<number[]>([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
 
   useEffect(() => {
@@ -134,15 +132,15 @@ const QuizPreview = () => {
   };
 
   const updateTaggedQuestion = (questionIndex: number) =>
-    taggedQuestionIndex === questionIndex
-      ? setTaggedQuestionIndex(null)
-      : setTaggedQuestionIndex(questionIndex);
+    taggedQuestions.includes(questionIndex)
+      ? setTaggedQuestions((prev) => prev.filter((q) => q !== questionIndex))
+      : setTaggedQuestions((prev) => [...prev, questionIndex]);
 
   return (
     <QuizPreviewProvider
       value={{
         answers,
-        taggedQuestionIndex,
+        taggedQuestions,
         updateTaggedQuestion,
       }}
     >

--- a/src/Kanbas/Courses/Quizzes/Preview/index.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/index.tsx
@@ -83,14 +83,15 @@ const QuizPreview = () => {
   const [answers, setAnswers] = useState<string[][]>([]);
   const [taggedQuestions, setTaggedQuestions] = useState<number[]>([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
+  const [quizResults, setQuizResults] = useState<boolean[]>([]);
 
   useEffect(() => {
     // fetch quiz from BE
     const fetchQuiz = async () => {
       // TODO: replace with actual fetch call
-      setQuiz(JSON.parse(JSON.stringify(quizzes[0])));
+      setQuiz(JSON.parse(JSON.stringify(quizzes[1])));
       setAnswers(
-        quizzes[0].questions.map((question) =>
+        quizzes[1].questions.map((question) =>
           question.type === QuestionType.FILL_IN_THE_BLANK
             ? question.options.map(() => '')
             : ['']
@@ -114,6 +115,14 @@ const QuizPreview = () => {
       'grade teh quiz score for the preview test run but dont save it anywhere?'
     );
     console.log('submitted answers', answers);
+    const results = answers.map(
+      (userAnswers, index) =>
+        quiz?.questions[index].answers.every(
+          (ans, i) => ans === userAnswers[i]
+        ) ?? false
+    );
+    console.log('results', results);
+    setQuizResults(results);
   };
 
   const handleSaveAnswer = (

--- a/src/Kanbas/Courses/Quizzes/Preview/index.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/index.tsx
@@ -1,18 +1,12 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import QuizHeaderPreview from './QuizPreviewHeader';
 import QuizContent from './QuizContent';
 import QuestionList from './QuestionList';
-import { quizzes } from '../../../Database';
-import { useNavigate, useParams } from 'react-router';
+import { useParams } from 'react-router';
 import { QuizPreviewProvider } from '../context/QuizPreviewContext';
 import * as client from './client';
 import StatusBanner from './StatusBanner';
-
-export enum QuestionType {
-  MULTIPLE_CHOICE = 'Multiple Choice',
-  TRUE_FALSE = 'True/False',
-  FILL_IN_THE_BLANK = 'Fill in the Blank',
-}
+import { QuestionType, QuizType, AssignmentGroup } from './constants';
 
 export type Question = {
   _id: number;
@@ -23,20 +17,6 @@ export type Question = {
   answers: string[];
   options: string[];
 };
-
-export enum QuizType {
-  GRADED_QUIZ = 'Graded Quiz',
-  PRACTICE_QUIZ = 'Practice Quiz',
-  GRADED_SURVEY = 'Graded Survey',
-  UNGRADED_SURVEY = 'Ungraded Survey',
-}
-
-export enum AssignmentGroup {
-  QUIZZES = 'Quizzes',
-  ASSIGNMENTS = 'Assignments',
-  EXAMS = 'Exams',
-  PROJECTS = 'Projects',
-}
 
 export type Quiz = {
   _id: number;
@@ -60,28 +40,10 @@ export type Quiz = {
   untilDate: Date;
 };
 
-/*
-
-preview needs:
-- quiz title
-banner to say that it's a preview
-- date quiz started at (assume it's the datetime the moment the faculty click to preview the quiz)
-- show question either one at a time or all at once in a long vertical scroll
-- each question needs to show:
-  - title in top left
-  - description
-  - points in top right
-  - list of all answers in the proper input format
-  - next button to go to next question if there are more questions (dont show if it's the last question)
-- show submit button for overall quiz below question box and with the last updated at time next to it
-- show button below submit for going back to quiz editor screen for the particular question
-- at bottom, show list of all questions where the links are all clickable and the current question link is bolded
-*/
 const QuizPreview = () => {
   const { quizId } = useParams();
 
   const [quiz, setQuiz] = useState<Quiz | null>(null);
-  // TODO: the datatype of this array might need to change
   const [answers, setAnswers] = useState<string[][]>([]);
   const [taggedQuestions, setTaggedQuestions] = useState<number[]>([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
@@ -91,7 +53,6 @@ const QuizPreview = () => {
   useEffect(() => {
     // fetch quiz from BE
     const fetchQuiz = async () => {
-      // TODO: replace with actual fetch call
       if (!quizId) {
         return;
       }
@@ -119,17 +80,12 @@ const QuizPreview = () => {
     setCurrentQuestionIndex(index);
 
   const handleSubmit = () => {
-    console.log(
-      'grade teh quiz score for the preview test run but dont save it anywhere?'
-    );
-    console.log('submitted answers', answers);
     const results = answers.map(
       (userAnswers, index) =>
         quiz?.questions[index].answers.every(
           (ans, i) => ans === userAnswers[i]
         ) ?? false
     );
-    console.log('results', results);
     setQuizResults(results);
   };
 
@@ -138,9 +94,6 @@ const QuizPreview = () => {
     answerIndex: number,
     questionIndex: number
   ) => {
-    console.log(
-      'save the progress of the quiz after each answer change in browser state'
-    );
     setAnswers((prevAnswers) => {
       const newAnswers = [...prevAnswers];
       newAnswers[questionIndex][answerIndex] = answer;

--- a/src/Kanbas/Courses/Quizzes/context/QuizPreviewContext.tsx
+++ b/src/Kanbas/Courses/Quizzes/context/QuizPreviewContext.tsx
@@ -1,0 +1,27 @@
+import React, { createContext } from 'react';
+
+export interface QuizPreviewContextType {
+  answers: string[][];
+  taggedQuestionIndex: number | null;
+  updateTaggedQuestion: (questionIndex: number) => void;
+}
+
+export const QuizPreviewContext = createContext<QuizPreviewContextType | null>(
+  null
+);
+
+interface QuizPreviewProviderProps {
+  children: React.ReactNode;
+  value: QuizPreviewContextType;
+}
+
+export function QuizPreviewProvider({
+  children,
+  value,
+}: QuizPreviewProviderProps) {
+  return (
+    <QuizPreviewContext.Provider value={value}>
+      {children}
+    </QuizPreviewContext.Provider>
+  );
+}

--- a/src/Kanbas/Courses/Quizzes/context/QuizPreviewContext.tsx
+++ b/src/Kanbas/Courses/Quizzes/context/QuizPreviewContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext } from 'react';
 
 export interface QuizPreviewContextType {
   answers: string[][];
-  taggedQuestionIndex: number | null;
+  taggedQuestions: number[];
   updateTaggedQuestion: (questionIndex: number) => void;
 }
 

--- a/src/Kanbas/Courses/Quizzes/hooks/useQuizPreview.ts
+++ b/src/Kanbas/Courses/Quizzes/hooks/useQuizPreview.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { QuizPreviewContext } from '../context/QuizPreviewContext';
+
+export default function useQuizPreview() {
+  const quizPreviewContext = useContext(QuizPreviewContext);
+  if (!quizPreviewContext) {
+    throw new Error('useQuizPreview must be used within a QuizPreviewProvider');
+  }
+  return quizPreviewContext;
+}

--- a/src/Kanbas/Courses/index.tsx
+++ b/src/Kanbas/Courses/index.tsx
@@ -35,7 +35,7 @@ const Courses: React.FC<CoursesProps> = ({ courses }) => {
             <Route path='Piazza' element={<h1>Piazza</h1>} />
             <Route path='Assignments' element={<Assignments />} />
             <Route path='Quizzes' element={<Quizzes />} />
-            <Route path='Quizzes/:quizId/preview' element={<QuizPreview />} />
+            <Route path='Quizzes/:quizId/Preview' element={<QuizPreview />} />
             <Route
               path='Assignments/:assignmentId'
               element={<h1>Assignment Editor</h1>}

--- a/src/Kanbas/Database/quizzes.json
+++ b/src/Kanbas/Database/quizzes.json
@@ -27,8 +27,13 @@
         "type": "Multiple Choice",
         "points": 5,
         "description": "In Sesame Street, one of the Count’s love interests is _______, who tallies numbers in descending order.",
-        "options": ["Countess von Backwards","Cookie Monster", "Elmo", "Big Bird"],
-        "answers": ["Countess von Backwards" ]
+        "options": [
+          "Countess von Backwards",
+          "Cookie Monster",
+          "Elmo",
+          "Big Bird"
+        ],
+        "answers": ["Countess von Backwards"]
       },
       {
         "_id": 4,
@@ -45,7 +50,14 @@
         "type": "Fill in the Blank",
         "points": 5,
         "description": "Which of the following are a type of bird?",
-        "options": ["Eagle", "Hippopotamus", "Platypus", "Owl", "Penguin", "Walrus"],
+        "options": [
+          "Eagle",
+          "Hippopotamus",
+          "Platypus",
+          "Owl",
+          "Penguin",
+          "Walrus"
+        ],
         "answers": ["Eagle", "Owl", "Penguin"]
       },
       {
@@ -72,8 +84,8 @@
         "type": "Fill in the Blank",
         "points": 5,
         "description": "Fill in the blanks. The quick brown fox jumps over the lazy ______. ______ comes after Tuesday.",
-        "options": ["dog", "Wednesday"],
-        "answers": ["dog"]
+        "options": [""],
+        "answers": ["dog", "Wednesday"]
       }
     ],
     "title": "Quiz 1",
@@ -113,7 +125,7 @@
         "points": 2,
         "description": "How many sides does a stop sign have?",
         "options": ["1", "3", "4", "8", "12"],
-        "answers": []
+        "answers": ["8"]
       },
       {
         "_id": 10,


### PR DESCRIPTION
Added quiz preview:
- quiz preview is at route `/Kanbas/Courses/:courseId/Quizzes/:quizId/Preview`
- when `oneQuestionAtATime` is true on the quiz object, preview only shows 1 question box with next/prev buttons to navigate
- when `oneQuestionAtATime` is false on the quiz object, preview only shows all questions in a long column
- submit btn is disabled
- keep editing this quiz btn redirects to `/Kanbas/Courses/:courseId/Quizzes/:quizId` (i think this is the route for the quiz editor?)
- can click the tag next to question boxes to tag them, multiple questions can be tagged at the same time
- question list lets you manually navigate to a specific question and also displays which questions are tagged

possible things to add later:
- submitting and saving answers on the preview (this is apparently extra credit)

demo:

https://github.com/mike10911/kanbas-web-dev-warriors/assets/48561685/01137f12-0e50-441d-902a-a3f2787f0e81

