### PR TITLE
add error message when previewing a quiz with no questions

### DIFF
--- a/src/Kanbas/Courses/Quizzes/Preview/index.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/index.tsx
@@ -142,7 +142,7 @@ const QuizPreview = () => {
       }}
     >
       <div className='d-flex flex-column justify-content-center gap-1 mb-lg-4'>
-        {quiz && !error && (
+        {quiz && quiz.questions.length > 0 && !error && (
           <div
             className={`d-flex flex-xl-row flex-column gap-5 ${
               quizResults ? 'mb-5' : ''
@@ -177,6 +177,9 @@ const QuizPreview = () => {
               />
             )}
           </div>
+        )}
+        {quiz && quiz.questions.length === 0 && !error && (
+          <StatusBanner message='This quiz has no questions.' />
         )}
         {error && <StatusBanner message={error} />}
       </div>

--- a/src/Kanbas/Courses/Quizzes/Preview/index.tsx
+++ b/src/Kanbas/Courses/Quizzes/Preview/index.tsx
@@ -7,6 +7,8 @@ import { QuizPreviewProvider } from '../context/QuizPreviewContext';
 import * as client from './client';
 import StatusBanner from './StatusBanner';
 import { QuestionType, QuizType, AssignmentGroup } from './constants';
+import { MdOutlineEdit } from 'react-icons/md';
+import { Link } from 'react-router-dom';
 
 export type Question = {
   title: string;
@@ -45,7 +47,7 @@ export type QuestionResult = {
 };
 
 const QuizPreview = () => {
-  const { quizId } = useParams();
+  const { courseId, quizId } = useParams();
 
   const [quiz, setQuiz] = useState<Quiz | null>(null);
   const [answers, setAnswers] = useState<string[][]>([]);
@@ -179,7 +181,23 @@ const QuizPreview = () => {
           </div>
         )}
         {quiz && quiz.questions.length === 0 && !error && (
-          <StatusBanner message='This quiz has no questions.' />
+          <>
+            <StatusBanner message='This quiz has no questions.' />
+            <hr className='mb-0 mt-5' />
+            <Link
+              to={`/Kanbas/Courses/${courseId}/Quizzes/${quizId}`}
+              className='w-100 mt-4 text-decoration-none'
+            >
+              <button className='btn wd-modules-btn d-flex justify-content-start gap-1 w-100'>
+                <MdOutlineEdit
+                  style={{
+                    transform: 'rotateY(180deg)',
+                  }}
+                />
+                Keep Editing This Quiz
+              </button>
+            </Link>
+          </>
         )}
         {error && <StatusBanner message={error} />}
       </div>


### PR DESCRIPTION
Display an error banner on quiz preview if trying to preview a quiz with no questions

<img width="1470" alt="Screenshot 2024-04-21 at 9 00 48 PM" src="https://github.com/mike10911/kanbas-web-dev-warriors/assets/48561685/75cc8c33-88bf-4b19-b295-3e07caf122d4">
